### PR TITLE
Triggers workflow on develop branch PR closure

### DIFF
--- a/.github/workflows/update-prs.yml
+++ b/.github/workflows/update-prs.yml
@@ -1,7 +1,9 @@
 name: Update PRs on develop merge
 
 on:
-  push:
+  pull_request:
+    types:
+      - closed
     branches:
       - develop
 


### PR DESCRIPTION
Updates the GitHub Actions workflow to trigger when a pull request targeting the develop branch is closed. This change ensures processes that need to run after a PR merges are automatically initiated.

Relates to "feature/config-ignore-action"