### PR TITLE
Removes redundant comment from release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,4 +16,4 @@ jobs:
       - run: npx semantic-release
         env:
           GITHUB_TOKEN: ${{ secrets.GH_PAT }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }} # Si publicas en npm
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
Cleanups in the release workflow file:
- Removes a redundant comment related to NPM_TOKEN usage

Part of the ongoing feature enhancements in the branch "feature/commit".