### PR TITLE
Replaces semantic-release with manual npm publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,6 @@ jobs:
         with:
           node-version: '18'
       - run: npm install
-      - run: npx semantic-release
+      - run: npm publish --access public
         env:
-          GITHUB_TOKEN: ${{ secrets.GH_PAT }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/release.config.js
+++ b/release.config.js
@@ -3,15 +3,7 @@ module.exports = {
   plugins: [
     '@semantic-release/commit-analyzer',
     '@semantic-release/release-notes-generator',
-    '@semantic-release/changelog',
     '@semantic-release/github',
-    '@semantic-release/npm',
-    [
-      '@semantic-release/git',
-      {
-        assets: ['CHANGELOG.md', 'package.json'],
-        message: 'chore(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}'
-      }
-    ]
+    '@semantic-release/npm'
   ]
 };


### PR DESCRIPTION
Switches from semantic-release to a manual `npm publish` process to simplify release management:
- Removes semantic-release plugins and associated configuration
- Updates environment variables for npm authentication

Relates to feature/config-changelog