### PR TITLE
release: 2.0.1 — express lazy loading fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@smdv/logwise",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Professional logging library for Node.js microservices with i18n support, multiple levels, JSON format, Express middleware, HTTP decorators and extensible transports",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/decorators/route.decorator.ts
+++ b/src/decorators/route.decorator.ts
@@ -17,8 +17,19 @@
  */
 
 import 'reflect-metadata';
-import { Request, Response, Router, Application } from 'express';
+import type { Request, Response, Router, Application } from 'express';
 import { Logger } from '../logger';
+
+// Lazy getter — express solo se carga si realmente se usan los decorators
+function getExpress() {
+  try {
+    return require('express');
+  } catch {
+    throw new Error(
+      '[@smdv/logwise] express is required to use route decorators. Install it: npm i express'
+    );
+  }
+}
 
 // Logger interno para decoradores
 const decoratorLogger = new Logger({ service: 'logwise-decorators' });
@@ -223,7 +234,8 @@ export function registerControllers(
     const prefix: string = Reflect.getMetadata(CONTROLLER_PREFIX_KEY, ControllerClass) || '';
     
     // Crear router y registrar rutas
-    const router = Router();
+    const { Router: ExpressRouter } = getExpress();
+    const router = ExpressRouter();
     registerRoutes(router, controllerInstance, options);
     
     // Montar router en la app


### PR DESCRIPTION
## Cambios incluidos

- **fix:** express se carga con lazy loading en `route.decorator.ts` — servicios que no usan decoradores de rutas ya no fallan si express no está instalado

## Tipo de release

Patch (`2.0.1`) — corrección de un bug en peer dependency opcional.

🤖 Generated with [Claude Code](https://claude.com/claude-code)