### PR TITLE
feat: log context (ownerId) via shared AsyncLocalStorage

### DIFF
--- a/catalog.yaml
+++ b/catalog.yaml
@@ -1,0 +1,88 @@
+# catalog.yaml — logwise
+# Engineering Intelligence & Release Governance Platform
+# Schema version: 1.1 | Last updated: 2026-06-11
+
+app_id: logwise
+name: Logwise Library
+description: >
+  Librería npm de logging estructurado para todos los microservicios Node.js
+  de Smart Sale. Publicada como @smdv/logwise. Estandariza formato de logs,
+  niveles, contexto de request y soporte XML. Usada por todos los MS Node.js
+  del stack — cambios tienen impacto transversal.
+type: lib
+status: active
+
+ownership:
+  squad: platform
+  owner_team: core
+  jira_component: logwise
+
+stack:
+  framework: node
+  runtime: node
+  language: typescript
+  version:
+    runtime: "18.x"
+    framework: null
+
+repository:
+  provider: codecommit
+  name: logwise
+  branch_default: develop
+  workspace_path: utilities/logwise
+
+deployment:
+  type: npm
+  package_name: "@smdv/logwise"
+  package_version: "2.1.0"
+  pipeline_name: logwise-pipeline
+
+communication:
+  http_clients: []
+  kafka_producer: []
+  kafka_consumer: []
+
+  shared:
+    mysql: false
+    redis: false
+    kafka: false
+    dynamodb: false
+
+health_profile:
+  last_reviewed: "2026-06-11"
+  reviewer: jhernandez
+
+  technical_debt:
+    level: low
+    notes: >
+      v2.1.0 activa y estable. Proceso de publicación npm documentado en
+      docs/LOGWISE.md. Migración de console.* y Adonis Logger hacia logwise
+      en 14 servicios planificada en docs/LOGWISE-MIGRATION-PLAN.md.
+      buildspec usa Node 18 — considerar actualizar a 20.x para alinear con
+      el runtime de los microservicios.
+
+  architecture:
+    has_defined_arch: true
+    follows_patterns: full
+    patterns_missing: []
+
+  policy_compliance:
+    secrets_manager: false
+    no_hardcoded_env: true
+    auth_pattern: false
+    conventional_commits: true
+
+  test_coverage:
+    current_pct: 0
+    new_code_target_pct: 85
+    has_unit_tests: true
+    has_integration_tests: false
+    notes: >
+      Tiene directorio __tests__ en src/. Cobertura real no medida.
+      Librería transversal — tests son críticos para evitar regresiones
+      silenciosas en todos los MS.
+
+  documentation:
+    has_readme: false
+    has_claude_md: false
+    has_adr: false

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@smdv/logwise",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "description": "Professional logging library for Node.js microservices with i18n support, multiple levels, JSON format, Express middleware, HTTP decorators and extensible transports",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/__tests__/context-store.test.ts
+++ b/src/__tests__/context-store.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect, beforeEach } from '@jest/globals';
+import { Logger } from '../logger';
+import { LogLevel, SupportedLang, LogTransport } from '../types';
+import { runWithLogContext, getLogContext, setLogContext } from '../context-store';
+
+class TestTransport implements LogTransport {
+  public logs: Record<string, any>[] = [];
+  write(entry: Record<string, any>): void {
+    this.logs.push(entry);
+  }
+}
+
+describe('log context (AsyncLocalStorage)', () => {
+  const transport = new TestTransport();
+  const logger = new Logger({ level: LogLevel.DEBUG, lang: SupportedLang.ES }, [transport]);
+
+  beforeEach(() => {
+    transport.logs = [];
+  });
+
+  it('injects context fields into every log line emitted within the scope', () => {
+    runWithLogContext({ ownerId: 'tenant-123', userId: 'user-9' }, () => {
+      logger.info('Algo paso');
+    });
+    const entry = transport.logs[0];
+    expect(entry.ownerId).toBe('tenant-123');
+    expect(entry.userId).toBe('user-9');
+  });
+
+  it('omits context fields outside any scope', () => {
+    logger.info('Sin contexto');
+    expect(transport.logs[0].ownerId).toBeUndefined();
+  });
+
+  it('lets explicit meta override the context', () => {
+    runWithLogContext({ ownerId: 'tenant-123' }, () => {
+      logger.info('Override', undefined, { ownerId: 'tenant-override' });
+    });
+    expect(transport.logs[0].ownerId).toBe('tenant-override');
+  });
+
+  it('inherits parent context when nested', () => {
+    runWithLogContext({ ownerId: 'tenant-123' }, () => {
+      runWithLogContext({ requestId: 'req-1' }, () => {
+        logger.info('Anidado');
+      });
+    });
+    const entry = transport.logs[0];
+    expect(entry.ownerId).toBe('tenant-123');
+    expect(entry.requestId).toBe('req-1');
+  });
+
+  it('setLogContext updates the active scope', () => {
+    runWithLogContext({ ownerId: 'tenant-123' }, () => {
+      setLogContext({ enterpriseId: 'ent-7' });
+      logger.info('Actualizado');
+      expect(getLogContext()?.enterpriseId).toBe('ent-7');
+    });
+  });
+
+  it('isolates context between concurrent async scopes', async () => {
+    const results: Record<string, string | undefined> = {};
+    await Promise.all([
+      new Promise<void>((resolve) =>
+        runWithLogContext({ ownerId: 'A' }, async () => {
+          await new Promise((r) => setTimeout(r, 10));
+          results.a = getLogContext()?.ownerId as string;
+          resolve();
+        }),
+      ),
+      new Promise<void>((resolve) =>
+        runWithLogContext({ ownerId: 'B' }, async () => {
+          results.b = getLogContext()?.ownerId as string;
+          resolve();
+        }),
+      ),
+    ]);
+    expect(results.a).toBe('A');
+    expect(results.b).toBe('B');
+  });
+});

--- a/src/context-store.ts
+++ b/src/context-store.ts
@@ -1,0 +1,53 @@
+import { AsyncLocalStorage } from 'async_hooks';
+
+/**
+ * Contexto de log por request.
+ *
+ * Mecanismo: un AsyncLocalStorage compartido a nivel de proceso vía el
+ * registro global de símbolos (`Symbol.for`). Esto permite que `@smdv/middleware`
+ * (que NO depende de logwise) pueble el mismo store sin acoplarse a este paquete:
+ * ambos paquetes resuelven la MISMA instancia de ALS a través de la clave global.
+ *
+ * El middleware de auth abre el contexto al inicio del request con el `ownerId`
+ * (clave de tenant, ver ADR-003) y `emit()` lo mezcla en cada línea de log
+ * automáticamente — sin tocar las llamadas `logger.*` de cada servicio.
+ *
+ * En Kafka/jobs sin request inbound el store queda vacío y los campos
+ * simplemente no aparecen (comportamiento correcto).
+ */
+export type LogContext = Record<string, string | number | boolean | undefined>;
+
+const STORE_KEY = Symbol.for('@smdv/log-context');
+
+function getStore(): AsyncLocalStorage<LogContext> {
+  const g = globalThis as unknown as Record<symbol, AsyncLocalStorage<LogContext>>;
+  if (!g[STORE_KEY]) {
+    g[STORE_KEY] = new AsyncLocalStorage<LogContext>();
+  }
+  return g[STORE_KEY];
+}
+
+/**
+ * Ejecuta `fn` con un contexto de log activo. Hereda el contexto padre si
+ * existe (merge), así que se puede anidar sin perder campos previos.
+ */
+export function runWithLogContext<T>(context: LogContext, fn: () => T): T {
+  const store = getStore();
+  const parent = store.getStore();
+  const merged: LogContext = { ...(parent || {}), ...context };
+  return store.run(merged, fn);
+}
+
+/** Devuelve el contexto de log activo (o undefined fuera de un request). */
+export function getLogContext(): LogContext | undefined {
+  return getStore().getStore();
+}
+
+/**
+ * Agrega/actualiza campos en el contexto activo sin abrir uno nuevo.
+ * No hace nada si no hay contexto activo.
+ */
+export function setLogContext(context: LogContext): void {
+  const current = getStore().getStore();
+  if (current) Object.assign(current, context);
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,9 @@ export { LogLevel, OutputFormat, Environment, SupportedLang, LoggerConfig, Trans
 export { ENV_KEYS, DEFAULTS } from './constants';
 export { createCustomLogger } from './factory';
 
+// Contexto de log por request (AsyncLocalStorage). Poblado por @smdv/middleware.
+export { runWithLogContext, getLogContext, setLogContext, LogContext } from './context-store';
+
 // Decorators - Decoradores HTTP estilo NestJS para Express
 export {
   // Route decorators

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -1,4 +1,5 @@
 import { ENV_KEYS, DEFAULTS } from './constants';
+import { getLogContext } from './context-store';
 import { LogLevel, Environment, OutputFormat, SupportedLang, LogTransport } from './types';
 import { LoggerConfig, HttpStatusCode, ApplicationErrorCode, ErrorContext } from './types';
 import { XmlProcessor } from './xml';
@@ -121,11 +122,16 @@ export class Logger {
     if (!this.shouldLog(level)) return;
 
     const { clean, stack } = this.extractMeta(meta);
+    // Contexto por request (ownerId, userId, requestId, ...) inyectado por
+    // @smdv/middleware vía AsyncLocalStorage. El meta explícito de la llamada
+    // tiene prioridad sobre el contexto (se aplica después).
+    const ctx = getLogContext();
     const entry: Record<string, any> = {
       level,
       message,
       service: this.config.service,
       timestamp: this.timestamp(),
+      ...(ctx || {}),
       ...clean,
       ...(stack ? { stack } : {}),
     };


### PR DESCRIPTION
## Qué

Añade contexto de log por request basado en AsyncLocalStorage. Cada línea de log emitida dentro del scope de una request incluye automáticamente `ownerId`, `userId`, `enterpriseId` sin pasarlos manualmente en cada `logger.info`.

## Cómo

- `src/context-store.ts`: ALS compartido vía `globalThis[Symbol.for('@smdv/log-context')]` — permite que `@smdv/middleware` abra el contexto y `logwise` lo lea, sin acoplar los paquetes.
- `logger.emit()`: hace merge del contexto activo en el entry (los campos explícitos de `meta` tienen prioridad).
- Exporta `runWithLogContext`, `getLogContext`, `setLogContext`, `LogContext`.
- Tests: 6 casos (inyección, scope, override, herencia anidada, setLogContext, aislamiento async concurrente).

## Versión
`2.1.0` → `2.2.0`

Parte de F0.2 (metering/FinOps multi-tenant). PRs hermanos en middleware y ms-billing-subscriptions.